### PR TITLE
Update for v8 4.5 by s/Handle/Local/

### DIFF
--- a/src/c++/engine.cpp
+++ b/src/c++/engine.cpp
@@ -37,7 +37,7 @@ Engine::~Engine() {
   if (_active) lzma_end(&_stream);
 }
 
-void Engine::Init(v8::Handle<v8::Object> exports) {
+void Engine::Init(v8::Local<v8::Object> exports) {
   Nan::HandleScope scope;
 
   // constructor template
@@ -109,7 +109,7 @@ NAN_METHOD(Engine::Feed) {
 
   if (info.Length() != 1) Nan::ThrowTypeError("Requires 1 argument: <buffer>");
 
-  v8::Handle<v8::Object> buffer = info[0]->ToObject();
+  v8::Local<v8::Object> buffer = info[0]->ToObject();
   if (!node::Buffer::HasInstance(buffer)) Nan::ThrowTypeError("Argument must be a buffer");
   obj->_stream.next_in = (const uint8_t *) node::Buffer::Data(buffer);
   obj->_stream.avail_in = node::Buffer::Length(buffer);
@@ -127,7 +127,7 @@ NAN_METHOD(Engine::Drain) {
   if (!obj->_active) Nan::ThrowError("Engine has already been closed");
   if (info.Length() < 1 || info.Length() > 2) Nan::ThrowTypeError("Requires 1 or 2 arguments: <buffer> [<flags>]");
 
-  v8::Handle<v8::Object> buffer = info[0]->ToObject();
+  v8::Local<v8::Object> buffer = info[0]->ToObject();
   if (!node::Buffer::HasInstance(buffer)) Nan::ThrowTypeError("Argument must be a buffer");
 
   int flags = (info.Length() > 1) ? info[1]->IntegerValue() : 0;

--- a/src/c++/engine.h
+++ b/src/c++/engine.h
@@ -11,7 +11,7 @@
  */
 class Engine : public Nan::ObjectWrap {
 public:
-  static void Init(v8::Handle<v8::Object> exports);
+  static void Init(v8::Local<v8::Object> exports);
 
 private:
   explicit Engine(void);

--- a/src/c++/node_xz.cpp
+++ b/src/c++/node_xz.cpp
@@ -4,7 +4,7 @@
 
 #include "engine.h"
 
-void init(v8::Handle<v8::Object> exports) {
+void init(v8::Local<v8::Object> exports) {
   Engine::Init(exports);
 }
 


### PR DESCRIPTION
In v8 4.5 Handle is now deprecated and is replaced by Local ([Embeders Guide - v8 handles](https://developers.google.com/v8/embed#handles)) - this PR just replaces s/Handle/Local/.

The tests pass against v8 '4.4.63.30' (in iojs 3.3.0) and should hopefully improve compatibility with the imminent nodejs/iojs V4 which is expected to include v8 4.5.( [see discussion for v8 in nodejs v4](https://github.com/nodejs/node/pull/2632)).
