### PR TITLE
Use SPDX-compliant license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "type": "git",
     "url": "git://github.com/robey/node-xz.git"
   },
-  "licenses": [
-    {
-      "type": "Apache License 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-    }
-  ],
+  "license": "Apache-2.0",
   "scripts": {
     "build": "npm run prepublish",
     "clean": "rm -rf lib test/lib build",


### PR DESCRIPTION
Since a few versions, npm suggests that package.json contains a SPDX-compliant `license` field, rather than the deprecated `licenses` field or other formats. `npm install` currently leads to the following warning:
`npm WARN package.json xz@1.2.0 No license field.`


See https://docs.npmjs.com/files/package.json#license for more information.