### PR TITLE
require nan 2.2 for node 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run build && npm run build-test && mocha -R spec --colors test/lib"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",


### PR DESCRIPTION
Update package.json to use nan 2.2 for compatibility with node 6.

`npm run test`  passes successfully using both node 6.0.0 and node 5.11.0.